### PR TITLE
Pkg 5061 pyinstaller hooks contrib

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
- - https://staging.continuum.io/prefect/fs/pyinstaller-feedstock/pr9/90cb5eb
+ - https://staging.continuum.io/prefect/fs/pyinstaller-feedstock/pr10/ea15432

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+ - https://staging.continuum.io/prefect/fs/pyinstaller-feedstock/pr9/90cb5eb

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
- - https://staging.continuum.io/prefect/fs/pyinstaller-feedstock/pr10/ea15432
- - https://staging.continuum.io/prefect/fs/pefile-feedstock/pr3/70149e3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
  - https://staging.continuum.io/prefect/fs/pyinstaller-feedstock/pr10/ea15432
+ - https://staging.continuum.io/prefect/fs/pefile-feedstock/pr3/70149e3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    - setuptools >=42.0.0
     - importlib_metadata >=4.6  # [py<310]
     - packaging >=22.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - pytest-xdist
     - execnet >=1.5.0
     - psutil
-    - pyinstaller {{ pyinstaller }}
+    - pyinstaller
   commands:
     - pip check
     - pytest src/_pyinstaller_hooks_contrib/tests/test_libraries.py -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
   skip: True  # [py<37]
+  entry_points:
+    - hook-dirs = _pyinstaller_hooks_contrib.hooks:get_hook_dirs
+    - tests = _pyinstaller_hooks_contrib.tests:get_test_dirs
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - pytest-xdist
     - execnet >=1.5.0
     - psutil
-    - pyinstaller
+    - pyinstaller {{ pyinstaller }}
   commands:
     - pip check
     - pytest src/_pyinstaller_hooks_contrib/tests/test_libraries.py -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,6 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
   skip: True  # [py<37]
-  entry_points:
-    - hook-dirs = _pyinstaller_hooks_contrib.hooks:get_hook_dirs
-    - tests = _pyinstaller_hooks_contrib.tests:get_test_dirs
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/v{{ version }}.tar.gz
-  sha256: fd5f37dcf99bece184e40642af88be16a9b89613ecb958a8bd1136634fc9fac5
+  sha256: 6bc703891fe21e8b983483a87b1a21a2ec6d3329575a6955457e639449efe78b
 
 build:
   number: 0
@@ -25,15 +25,28 @@ requirements:
     - wheel
   run:
     - python
+    - setuptools >=42.0.0
+    - importlib_metadata >=4.6  # [py<310]
+    - packaging >=22.0
 
 test:
+  source_files:
+    - src/_pyinstaller_hooks_contrib/tests
+    - src/_pyinstaller_hooks_contrib/tests/scripts
+    - src/_pyinstaller_hooks_contrib/tests/data/test_hydra
   imports:
     - _pyinstaller_hooks_contrib
-    - _pyinstaller_hooks_contrib.hooks
   requires:
     - pip
+    - pytest >=2.7.3
+    - pytest-timeout
+    - pytest-xdist
+    - execnet >=1.5.0
+    - psutil
+    - pyinstaller
   commands:
     - pip check
+    - pytest src/_pyinstaller_hooks_contrib/tests/test_libraries.py -v
 
 about:
   home: https://github.com/pyinstaller/pyinstaller-hooks-contrib
@@ -54,5 +67,7 @@ about:
   dev_url: https://github.com/pyinstaller/pyinstaller-hooks-contrib
 
 extra:
+  skip-lints:
+    - python_build_tool_in_run
   recipe-maintainers:
     - nehaljwani

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyinstaller-hooks-contrib" %}
-{% set version = "2022.14" %}
+{% set version = "2024.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/v{{ version }}.tar.gz
-  sha256: e5c94b9720545f8dadc105270ae16cafb2b4189e08dbf469104218cdcda2abef
+  sha256: fd5f37dcf99bece184e40642af88be16a9b89613ecb958a8bd1136634fc9fac5
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,5 @@ about:
   dev_url: https://github.com/pyinstaller/pyinstaller-hooks-contrib
 
 extra:
-  skip-lints:
-    - python_build_tool_in_run
   recipe-maintainers:
     - nehaljwani


### PR DESCRIPTION
### Overview
For latest pyinstaller. Jira: https://anaconda.atlassian.net/browse/PKG-5062
[Upstream](https://github.com/pyinstaller/pyinstaller-hooks-contrib)

Dependency Chain:
`pefile` > `pyinstaller 5.13.2` (rebuild for win) > `pyinstaller-hooks-contrib` > `pyinstaller 6.7.0`

Related PRs:
[`pefile`](https://github.com/AnacondaRecipes/pefile-feedstock/pull/3)
[`pyinstaller` rebuild](https://github.com/AnacondaRecipes/pyinstaller-feedstock/pull/10)